### PR TITLE
Fix incorrect member name in shouldDisplayHistoricalTools()

### DIFF
--- a/src/components/Pages/HeatMapPage/HeatMapPage.js
+++ b/src/components/Pages/HeatMapPage/HeatMapPage.js
@@ -173,7 +173,7 @@ class HeatMapPage extends Component {
   shouldDisableHistoricalTools() {
     return (
       this.shouldDisplayHistoricalTools() &&
-      !this.props.historicalHeatMapData.result
+      !this.props.historicalHeatMapData.data
     );
   }
 


### PR DESCRIPTION
Referred to `this.props.historicalHeatMapData.result`, instead of `this.props.historicalHeatMapData.data`, which resulted in incorrect rendering of the disabled Historical HeatMap view.