### PR TITLE
Correct error in data schema for historical heat maps

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -71,9 +71,10 @@ const eventReducer = (event, action) => {
       };
     case "SET_HEATMAP_SLIDER_VALUE": {
       const index = action.payload.sliderValue;
-      const selectedTimestamp = event.historicalHeatMapData.timestamps[index];
+      const selectedTimestamp =
+        event.historicalHeatMapData.result.timestamps[index];
       const selectedHeatMapData =
-        event.historicalHeatMapData.data[selectedTimestamp];
+        event.historicalHeatMapData.result.data[selectedTimestamp];
       return {
         ...event,
         heatMapData: selectedHeatMapData,

--- a/src/tools/src/mocks/data/tasks.js
+++ b/src/tools/src/mocks/data/tasks.js
@@ -76,14 +76,16 @@ const addHistoricalHeatMapToTaskList = (taskListForEvent, eventID) => {
     {
       eventID: eventID,
       taskID: 4,
-      timestamps: timestamps,
-      data: timestamps.reduce(
-        (acc, timestamp) => ({
-          ...acc,
-          [timestamp]: generateHeatMap(eventID)
-        }),
-        {}
-      )
+      result: {
+        timestamps: timestamps,
+        data: timestamps.reduce(
+          (acc, timestamp) => ({
+            ...acc,
+            [timestamp]: generateHeatMap(eventID)
+          }),
+          {}
+        )
+      }
     }
   ];
 };


### PR DESCRIPTION
`data` and `timestamps` fields should have been nested under a `results` attribute.