### PR TITLE
Display description field for emergency notifications

### DIFF
--- a/src/components/Sidebar/EmergencyNotificationBell/EmergencyNotificationBell.js
+++ b/src/components/Sidebar/EmergencyNotificationBell/EmergencyNotificationBell.js
@@ -47,11 +47,11 @@ class EmergencyNotificationBell extends Component {
       notification => ({
         icon: "warning-sign",
         title: (
-          <span>
-            <strong>Emergency</strong> at
-            {` ${this.getRegionName(notification.regionIds)}`}
-          </span>
+          <strong>
+            Emergency at {`${this.getRegionName(notification.regionIds)}`}
+          </strong>
         ),
+        description: notification.description,
         timestamp: notification.occurredAt,
         notificationID: notification.uuid + "|" + notification.occurredAt,
         resolved: notification.dealtWith

--- a/src/components/UI/NotificationPanel/NotificationPanel.js
+++ b/src/components/UI/NotificationPanel/NotificationPanel.js
@@ -37,6 +37,7 @@ export class NotificationPanel extends Component {
         <Icon icon={notification.icon} iconSize={20} />
         <div className={styles.content}>
           <h3 className={styles.title}>{notification.title}</h3>
+          <p className={styles.description}>{notification.description}</p>
           <p className={styles.timestamp}>
             {this.formatTimestamp(notification.timestamp)}
           </p>

--- a/src/components/UI/NotificationPanel/NotificationPanel.module.scss
+++ b/src/components/UI/NotificationPanel/NotificationPanel.module.scss
@@ -24,7 +24,13 @@
     margin: 0 0 5px 0;
   }
 
+  .description {
+    margin: 0;
+    padding: 4px 0 8px 0;
+  }
+
   .timestamp {
+    font-size: 14px;
     margin-bottom: 0;
     opacity: 0.7;
   }


### PR DESCRIPTION
Description field in notifications was being ignored, it's now displayed in the panel alongside the notification title.